### PR TITLE
[FEAT] Client 클래스 구현

### DIFF
--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -1,0 +1,15 @@
+#ifndef CLIENT_HPP
+#define CLIENT_HPP
+
+#include <unistd.h>
+
+class Client {
+private:
+    const int _client_fd;
+
+public:
+    Client(int);
+    ~Client();
+};
+
+#endif

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -7,6 +7,9 @@
 #include <sys/event.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <map>
+
+#include "Client.hpp"
 
 class Server {
 private:
@@ -16,6 +19,7 @@ private:
     const int _server_fd;
     struct sockaddr_in _server_addr;
     const int _kqueue_fd;
+    std::map<int, Client*> _clients;
 
     void initServerInfo();
     void connectNewClient();

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -1,0 +1,32 @@
+#ifndef SERVER_HPP
+#define SERVER_HPP
+
+#include <iostream>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/event.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+class Server {
+private:
+    // member variables
+    const int _port;
+    const std::string _password;
+    const int _server_fd;
+    struct sockaddr_in _server_addr;
+    const int _kqueue_fd;
+
+    void initServerInfo();
+    void connectNewClient();
+    void handleClientEvent(struct kevent &);
+    void removeClient(int);
+
+public:
+    Server(int, std::string);
+    ~Server();
+
+    void run();
+};
+
+#endif

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -1,0 +1,9 @@
+#include "../includes/Client.hpp"
+
+Client::Client(int fd) : _client_fd(fd) {
+    (void) _client_fd;
+}
+
+Client::~Client() {
+    close(_client_fd);
+}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,0 +1,121 @@
+#include "../includes/Server.hpp"
+
+Server::Server(int port, std::string password)
+    : _port(port),
+      _password(password),
+      _server_fd(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)),
+      _kqueue_fd(kqueue()) {
+    // 소켓 (IPv4, TCP)
+    if (_server_fd < 0) {
+        throw std::runtime_error("Socket creation failed");
+    }
+    if (_kqueue_fd < 0) {
+        throw std::runtime_error("Kqueue creation failed");
+    }
+
+    initServerInfo();
+    // client의 요청을 기다리기 시작
+    if (listen(_server_fd, 5) < 0) {
+        throw std::runtime_error("Listen failed");
+    }
+    std::cout << "IRC server is running on port: " << _port << "\n";
+}
+
+Server::~Server() {
+    close(_server_fd);
+    close(_kqueue_fd);
+    // TODO: client 소켓 전부 close
+}
+
+void Server::initServerInfo() {
+    // SOL_SOCKET의 SO_REUSEADDR은 커널에서 이미 바인딩한 주소를 재사용 하게 해줌 (에러 방지)
+    int opt = 1;
+    if (setsockopt(_server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
+        throw std::runtime_error("Setsockopt failed");
+    }
+
+    memset(&_server_addr, 0, sizeof(_server_addr));
+    _server_addr.sin_family = AF_INET;                   // 주소체계: ipv4
+    _server_addr.sin_addr.s_addr = htonl(INADDR_ANY);    // INADDR_ANY 자신의 모든 랜카드로 ip를 받을 수 있음
+    _server_addr.sin_port = htons(_port);                // Server ip의 PORT번호 지정
+
+    // socket과 ip를 연결하는 작업
+    if (bind(_server_fd, (struct sockaddr *)&_server_addr, sizeof(_server_addr)) < 0) {
+        throw std::runtime_error("Bind failed");
+    }
+}
+
+void Server::run() {
+    // kqueue에 server_socket 등록
+    // EVFILT_READ: 읽기 이벤트
+    // EV_ADD: 이벤트 등록
+    // EV_ENABLE: 이벤트 활성화
+    struct kevent change_event;
+    EV_SET(&change_event, _server_fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
+    if (kevent(_kqueue_fd, &change_event, 1, NULL, 0, NULL) < 0) {
+        throw std::runtime_error("Kevent registration failed");
+    }
+
+    while (true) {
+        // 발생한 event가 반환될 배열
+        struct kevent events[10];
+        int new_events = kevent(_kqueue_fd, NULL, 0, events, 10, NULL);
+        if (new_events < 0) {
+            throw std::runtime_error("Kevent failed");
+        }
+
+        for (int i = 0; i < new_events; ++i) {
+            if ((int)events[i].ident == _server_fd) {
+                connectNewClient();
+            } else if (events[i].filter == EVFILT_READ) {
+                handleClientEvent(events[i]);
+            }
+        }
+    }
+}
+
+void Server::connectNewClient() {
+    struct sockaddr_in client_addr;
+    socklen_t client_len = sizeof(client_addr);
+    int client_socket = accept(_server_fd, (struct sockaddr *)&client_addr, &client_len);
+    if (client_socket < 0) {
+        std::cerr << "Failed to accept new connection\n";
+        return;
+    }
+
+    std::string client_ip = std::string(inet_ntoa(client_addr.sin_addr));
+    int client_port = ntohs(client_addr.sin_port);
+    std::cout << "Client " << client_ip << ":" << client_port << " connected\n";
+
+    // TODO: client 저장해야 됨
+
+    struct kevent change_event;
+    EV_SET(&change_event, client_socket, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
+    if (kevent(_kqueue_fd, &change_event, 1, NULL, 0, NULL) < 0) {
+        std::cerr << "Failed to register client socket with kqueue\n";
+        removeClient(client_socket);
+    }
+}
+
+void Server::handleClientEvent(struct kevent &event) {
+    int client_socket = event.ident;
+    char buffer[1024] = {0};
+    ssize_t recv_byte = recv(client_socket, buffer, sizeof(buffer), 0);
+    if (recv_byte <= 0) {
+        std::cout << "Client disconnected\n";
+        removeClient(client_socket);
+        return;
+    }
+
+    std::cout << "Received: " << buffer << "\n";
+    std::string msg = "send: " + std::string(buffer);
+    send(client_socket, msg.c_str(), msg.size(), 0);
+}
+
+void Server::removeClient(int client_socket) {
+    struct kevent change_event;
+    EV_SET(&change_event, client_socket, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+    kevent(_kqueue_fd, &change_event, 1, NULL, 0, NULL);
+    close(client_socket);
+    // TODO: 저장된 client에서 해당 client 제거
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,138 +1,27 @@
-#include <iostream>
-#include <cstdlib>
-#include <cstring>
 #include <sstream>
-#include <sys/socket.h>
-#include <sys/event.h>
-#include <netinet/in.h>
-#include <arpa/inet.h> // inet_ntoa
-#include <unistd.h>
+#include "../includes/Server.hpp"
 
 int main(int ac, char **av) {
     if (ac != 3) {
-        std::cerr << "Invalid argument, need 2 arguments" << "\n";
-        std::cerr << "1st: Port number, 2nd: password" << "\n";
+        std::cerr << "Invalid argument, need 2 arguments\n";
+        std::cerr << "1st: Port number, 2nd: password\n";
         exit(1);
     }
 
     std::istringstream iss(av[1]);
-    int PORT;
-    iss >> std::noskipws >> PORT;
-    if (!iss.eof() || iss.fail() || PORT <= 0 || PORT > 65535){
-        std::cerr << "error!\n";
-        exit(1);
+    int port;
+    iss >> std::noskipws >> port;
+    if (!iss.eof() || iss.fail() || port <= 0 || port > 65535) {
+        std::cerr << "Invalid port number\n";
+        return 1;
     }
 
-    /*
-    //SECTION
-    domain - AF_INET = ipv4, 
-    type - SOCK_STREAM = tcp,
-    protocol - IPPROTO_TCP = TCP based socket
-    //!SECTION
-    */
-    int server_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-
-    //NOTE - SOL_SOCKET의 SO_REUSEADDR은 커널에서 이미 바인딩한 주소를 재사용 하게 해줌. (에러 방지)
-    bool opt = true;
-    setsockopt(server_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-
-    //NOTE - IPV$ socket address인 경우 sockaddr_in, 그 상위는 sockaddr
-    // 서버 주소 설정하는 과정.
-    struct sockaddr_in server_addr;
-    memset(&server_addr, 0, sizeof(server_addr));
-    // NOTE - 주소체계 : ipv4
-    server_addr.sin_family = AF_INET;
-    // NOTE - INADDR_ANY 자신의 모든 랜카드로 ip를 받을 수 있음.
-    server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-    // NOTE - Server ip의 PORT번호 지정
-    server_addr.sin_port = htons(PORT);
-
-    // NOTE - socket과 ip를 연경하는 작업
-    int binded = bind(server_socket, (struct sockaddr *)&server_addr, sizeof(server_addr));
-    if (binded != 0) {
-        std::cerr << "bind error!" << "\n";
-        exit(1);
+    try {
+        Server server(port, av[2]);
+        server.run();
+    } catch (std::exception &e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
     }
-
-    // NOTE - client의 요청을 기다리기 시작
-    binded = listen(server_socket, 5);
-    if (binded != 0) {
-        std::cerr << "bind error!" << "\n";
-        exit(1);
-    } else {
-        std::cout << "irc server is running on port: " << PORT << "\n";
-    }
-
-    // 새로운 event queue 생성
-    int kqueue_fd = kqueue();
-    if (kqueue_fd < 0){
-        std::cerr << "error!\n";
-        exit(1);
-    }
-
-    // kqueue에 server_socket 등록
-    // EVFILT_READ: 읽을 data가 있을 때마다 반환
-    // EV_ADD: kqueue에 이벤트 추가
-    // EV_ENABLE: kevent() 호출 시 event 반환 허용
-    struct kevent change_event;
-    EV_SET(&change_event, server_socket, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
-    if (kevent(kqueue_fd, &change_event, 1, NULL, 0, NULL) < 0) {
-        std::cerr << "error!\n";
-        exit(1);
-    }
-
-    while (true) {
-        // 발생한 event가 반환될 배열
-        struct kevent events[10];
-        int new_events = kevent(kqueue_fd, NULL, 0, events, 10, NULL);
-        if (new_events < 0) {
-            std::cerr << "error!\n";
-            exit(1);
-        }
-
-        for (int i = 0; i < new_events; ++i) {
-            if ((int)events[i].ident == server_socket) {
-                struct sockaddr_in client_addr;
-                socklen_t client_len = sizeof(client_addr);
-                int client_socket = accept(server_socket, (struct sockaddr *)&client_addr, &client_len);
-                if (client_socket == -1) {
-                    std::cerr << "get client socket error!" << "\n";
-                    exit(1);
-                }
-
-                std::string client_ip = std::string(inet_ntoa(client_addr.sin_addr));
-                int client_port = ntohs(client_addr.sin_port);
-                std::cout << "client " << client_ip << ":" << client_port << " connected\n" << "\n";
-
-                EV_SET(&change_event, client_socket, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
-                if (kevent(kqueue_fd, &change_event, 1, NULL, 0, NULL) < 0) {
-                    std::cerr << "error!\n";
-                    close(client_socket);
-                    continue;
-                }
-            } else if (events[i].filter == EVFILT_READ) {
-                int client_socket = events[i].ident;
-                char buffer[1024] = { 0, };
-                ssize_t recv_byte = recv(client_socket, buffer, sizeof(buffer), 0);
-                if (recv_byte == 0) {
-                    // std::cout << "client " << client_ip << ":" << client_port << " is leaved" << "\n";
-                    std::cout << "client disconnected\n";
-
-                    // client 소켓을 kqueue에서 제거
-                    EV_SET(&change_event, client_socket, EVFILT_READ, EV_DELETE, 0, 0, NULL);
-                    kevent(kqueue_fd, &change_event, 1, NULL, 0, NULL);
-
-                    close(client_socket);
-                    break;
-                }
-                std::cout << "received! : " << buffer << "\n";
-                
-                std::string msg = buffer;
-                msg = "send: " + msg;
-                send(client_socket, msg.c_str(), msg.size(), 0);
-            }
-        }
-    }
-
     return 0;
 }


### PR DESCRIPTION
### Server 클래스 구현
- main 함수 로직을 Server 클래스로 구현
- 2개 이상의 client 접속 확인 완료

### Client 클래스 구현
- Server 클래스에서 Client를 map으로 저장하고 있음 (key: client socket fd, value: Client class)
- new 로 Client를 생성했기 때문에 delete 해줘야 함 -> Server 소멸자에서 map에 저장된 Client 전부 delete 함
- Client 클래스를 생성할 때 어떤 값이 필요할지 몰라서 일단 client socket fd만 생성자로 넘김 -> 추후 추가 또는 수정