### PR TITLE
[FEAT] Client class에 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@
 *.out
 *.app
 ircserv
+
+.vscode

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -1,7 +1,11 @@
 #ifndef CLIENT_HPP
 #define CLIENT_HPP
+#define BUFFER_SIZE 1024
+#define SOCKET_LINE_SIZE 512
+#define CRLF "\r\n"
 
 #include <unistd.h>
+#include <sys/socket.h>
 #include <string>
 #include <iostream>
 
@@ -10,11 +14,34 @@ private:
     const int _client_fd;
     const int _client_port;
     const std::string _client_ip;
+    std::string _read_data;
+    std::string _write_data;
 
 public:
     Client(void);
     Client(int client_fd, int client_port, std::string client_ip);
     ~Client();
+
+    Client &operator<<(const std::string &data);
+    Client &operator>>(std::string &data);
+
+    Client &operator<<(const int socket_fd);
+    Client &operator>>(const int socket_fd);
+    
+    class ClientDisconnectException : public std::exception{
+    public:
+        const char *what(void) const throw();
+    };
+
+    class CannotFoundCRLFException : public std::exception{
+    public:
+        const char *what(void) const throw();
+    };
+
+    class LineTooLongException : public std::exception{
+    public:
+        const char *what(void) const throw();
+    };
 };
 
 #endif

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -2,13 +2,18 @@
 #define CLIENT_HPP
 
 #include <unistd.h>
+#include <string>
+#include <iostream>
 
 class Client {
 private:
     const int _client_fd;
+    const int _client_port;
+    const std::string _client_ip;
 
 public:
-    Client(int);
+    Client(void);
+    Client(int client_fd, int client_port, std::string client_ip);
     ~Client();
 };
 

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -7,6 +7,7 @@
 #include <sys/event.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <map>
 
 #include "Client.hpp"

--- a/input_test
+++ b/input_test
@@ -1,0 +1,3 @@
+CAP LS 302
+JOIN :
+CAP LS 302

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -1,7 +1,13 @@
 #include "../includes/Client.hpp"
 
-Client::Client(int fd) : _client_fd(fd) {
+Client::Client(void) 
+    : _client_fd(-1), _client_port(-1), _client_ip("") {}
+
+Client::Client(int client_fd, int client_port, std::string client_ip) 
+    : _client_fd(client_fd), _client_port(client_port), _client_ip(client_ip) {
     (void) _client_fd;
+    (void) _client_port;
+    (void) _client_ip;
 }
 
 Client::~Client() {

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -13,3 +13,57 @@ Client::Client(int client_fd, int client_port, std::string client_ip)
 Client::~Client() {
     close(_client_fd);
 }
+
+// read from client socket
+Client &Client::operator<<(const int socket_fd){
+    char buffer[BUFFER_SIZE] = {0, };
+    ssize_t recv_byte = recv(socket_fd, buffer, BUFFER_SIZE, 0);
+    if (recv_byte <= 0)
+        throw ClientDisconnectException();
+    _read_data += std::string(buffer, recv_byte);
+    return *this;
+}
+// write to client socket
+Client &Client::operator>>(const int socket_fd){
+    if (!_write_data.empty()){
+        ssize_t send_byte = send(socket_fd, _write_data.c_str(), _write_data.size(), 0);
+        if (send_byte <= 0)
+            throw ClientDisconnectException();
+        _write_data = _write_data.substr(send_byte);
+    }
+    return *this;
+}
+
+// data를 write data로 넣기
+Client &Client::operator<<(const std::string &line) {
+  _write_data += line;
+  return *this;
+}
+
+// 읽은 것을 string으로 내보내기
+Client &Client::operator>>(std::string &line) {
+    std::string::size_type pos = _read_data.find(CRLF);
+    if (pos == std::string::npos){
+        line.clear();
+        throw CannotFoundCRLFException();
+    }
+    if (pos + 2 > SOCKET_LINE_SIZE){
+        _read_data = _read_data.substr(pos + 2);    
+        throw LineTooLongException();
+    }
+    line = _read_data.substr(0, pos);
+    _read_data = _read_data.substr(pos + 2);
+    return *this;
+}
+
+const char* Client::ClientDisconnectException::what(void) const throw(){
+    return "Client disconnected";
+}
+
+const char* Client::CannotFoundCRLFException::what(void) const throw(){
+    return "Cannot found CRLF";
+}
+
+const char* Client::LineTooLongException::what(void) const throw(){
+    return "Command Line is Too long";
+}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -90,7 +90,7 @@ void Server::connectNewClient() {
     int client_port = ntohs(client_addr.sin_port);
     std::cout << "Client " << client_ip << ":" << client_port << " connected\n";
 
-    Client *new_client = new Client(client_socket);
+    Client *new_client = new Client(client_socket, client_port, client_ip);
     _clients[client_socket] = new_client;
 
     struct kevent change_event;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -91,7 +91,7 @@ void Server::connectNewClient() {
     std::cout << "Client " << client_ip << ":" << client_port << " connected\n";
 
     Client *new_client = new Client(client_socket);
-    _clients.insert({client_socket, new_client});
+    _clients[client_socket] = new_client;
 
     struct kevent change_event;
     EV_SET(&change_event, client_socket, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -14,6 +14,10 @@ Server::Server(int port, std::string password)
     }
 
     initServerInfo();
+
+    if (fcntl(_server_fd, F_SETFL, O_NONBLOCK) < 0){
+        throw std::runtime_error("non blocking socket create failed");
+    }
     // client의 요청을 기다리기 시작
     if (listen(_server_fd, 5) < 0) {
         throw std::runtime_error("Listen failed");


### PR DESCRIPTION
# Summary
Client class에 operator overloading 기능추가했습니다.

# 변경사항
* client class에 <<, >> operator 기능을 추가했습니다.
* fd_socket을 받는 경우는 client로부터 읽고, 쓰기기능을 수행합니다.
* std::string을 받는 경우에는 string에 client의 data를 쓰거나 읽습니다.
* client class의 생성자로 port 번호, ip 주소를 추가했습니다.
# 주의사항
* irssi는 \r\n으로 입력이 들어오는데, 현재 nc 127.0.0.1로는 \r\n을 입력할 수 없습니다. (엔터를 누르면 \n)이 들어갑니다.
* 그래서 `nc 127.0.0.1 8080 < input_test` 이렇게 테스트를 수행해야 합니다.
* 이때 input_test의 줄바꿈을 \r\n으로 해야합니다.
# 참고사항
* 현재는 JOIN: 이 명령어에 대한 대답만 한 상태이며, 이제 JOIN이 아무것도 없을때 메시지를 대충 띄우고 PASS 기능을 구현해야 합니다.