### PR TITLE
[FEAT] MSG 파싱 class 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@
 *.out
 *.app
 ircserv
+
+.vscode

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -21,6 +21,8 @@ public:
     Client(void);
     Client(int client_fd, int client_port, std::string client_ip);
     ~Client();
+    Client(const Client& obj);
+    Client& operator= (const Client& obj);
 
     Client &operator<<(const std::string &data);
     Client &operator>>(std::string &data);

--- a/includes/Message.hpp
+++ b/includes/Message.hpp
@@ -4,10 +4,12 @@
 #include <iostream>
 #include <string>
 #include <queue>
+#include <sstream>
 
 class Message {
 private:
 	std::queue<std::string> msg_queue;
+	std::vector<std::string> splitN(const std::string& str, char delimiter, size_t n);
 
 public:
 	Message(void);
@@ -16,7 +18,7 @@ public:
 	Message(const Message& obj);
 	Message& operator= (const Message& obj);
 
-	void get_client_msg(std::string str);
+	void getClientMsg(std::string str);
 };
 
 #endif

--- a/includes/Message.hpp
+++ b/includes/Message.hpp
@@ -1,0 +1,22 @@
+#ifndef __MESSAGE_HPP__
+#define __MESSAGE_HPP__
+
+#include <iostream>
+#include <string>
+#include <queue>
+
+class Message {
+private:
+	std::queue<std::string> msg_queue;
+
+public:
+	Message(void);
+	Message(std::string str);
+	~Message();
+	Message(const Message& obj);
+	Message& operator= (const Message& obj);
+
+	void get_client_msg(std::string str);
+};
+
+#endif

--- a/includes/Message.hpp
+++ b/includes/Message.hpp
@@ -3,13 +3,35 @@
 
 #include <iostream>
 #include <string>
-#include <queue>
 #include <sstream>
+#include <vector>
 
 class Message {
+public:
+	typedef enum CMD {
+		NONE,  // 0
+		CAP,
+		PASS,
+		NICK,
+		USER,
+		QUIT,
+		JOIN,
+		PART,
+		TOPIC,
+		MODE,
+		INVITE,
+		KICK,
+		PRIVMSG,
+		PING,
+		CMD_SIZE
+	} e_cmd;
+
 private:
-	std::queue<std::string> msg_queue;
+	static const std::string _commandList[CMD_SIZE + 1];
+	e_cmd _cmd_type;
+	std::string _params;
 	std::vector<std::string> splitN(const std::string& str, char delimiter, size_t n);
+	e_cmd findCommand(const std::string cmd_str);
 
 public:
 	Message(void);
@@ -18,7 +40,8 @@ public:
 	Message(const Message& obj);
 	Message& operator= (const Message& obj);
 
-	void getClientMsg(std::string str);
+	e_cmd getCommand(void);
+	const std::string getParams(void);
 };
 
 #endif

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -11,6 +11,7 @@
 #include <map>
 
 #include "Client.hpp"
+#include "Message.hpp"
 
 class Server {
 private:

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -29,8 +29,11 @@ private:
     void removeClient(int);
 
 public:
+    Server(void);
     Server(int, std::string);
     ~Server();
+    Server(const Server& obj);
+    Server& operator= (const Server& obj);
 
     void run();
 };

--- a/input_test
+++ b/input_test
@@ -1,3 +1,6 @@
 CAP LS 302
 JOIN :
-CAP LS 302
+PASS 123
+NICK sang
+USER root root 127.0.0.1 :root
+QUIT

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -1,7 +1,5 @@
 #include "../includes/Client.hpp"
 
-Client::Client(void) 
-    : _client_fd(-1), _client_port(-1), _client_ip("") {}
 
 Client::Client(int client_fd, int client_port, std::string client_ip) 
     : _client_fd(client_fd), _client_port(client_port), _client_ip(client_ip) {
@@ -66,4 +64,17 @@ const char* Client::CannotFoundCRLFException::what(void) const throw(){
 
 const char* Client::LineTooLongException::what(void) const throw(){
     return "Command Line is Too long";
+}
+
+Client::Client(void) : _client_fd(-1), _client_port(-1), _client_ip("") {
+    throw std::runtime_error("Client(): consturctor is not allowed");
+}
+
+Client::Client(const Client& obj) : _client_fd(obj._client_fd), _client_port(obj._client_port), _client_ip(obj._client_ip){
+    throw std::runtime_error("Client(): copy consturctor is not allowed");
+}
+Client& Client::operator= (const Client& obj){
+    (void) obj;
+    throw std::runtime_error("Client(): operator= is not allowed");
+    return *this;
 }

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -1,46 +1,13 @@
 #include "../includes/Message.hpp"
 
-// Message::Message(void){
+const std::string Message::_commandList[Message::CMD_SIZE + 1] = {
+	"NONE", "CAP", "PASS", 
+	"NICK", "USER", "QUIT", 
+	"JOIN", "PART", "TOPIC", 
+	"MODE", "INVITE", "KICK", 
+	"PRIVMSG", "PING"
+};
 
-// }
-Message::~Message(){}
-// Message::Message(const Message& obj){
-
-// }
-// Message& Message::operator= (const Message& obj){
-
-// }
-
-/*
-Tue Jul 16 2024 13:28:37 USERINPUT: C[811AAAAAI] I CAP LS 302
-Tue Jul 16 2024 13:28:37 USERINPUT: C[811AAAAAI] I JOIN :
-67 C
-65 A
-80 P
-32 ' '
-76 L
-83 S
-32 ' '
-51 3
-48 0
-50 2
-13 CR (\r)
-10 LF (\n)
-74 J
-79 O
-73 I
-78 N
-32 ' '
-58 ':'
-13 \r
-10 \n
-그다음 대기
-Tue Jul 16 2024 13:28:37 USEROUTPUT: C[811AAAAAI] O :irc.local 451 * JOIN :You have not registered.
-Tue Jul 16 2024 13:28:37 USERINPUT: C[811AAAAAI] I PASS 123
-Tue Jul 16 2024 13:28:37 USERINPUT: C[811AAAAAI] I NICK sang
-Tue Jul 16 2024 13:28:37 USERINPUT: C[811AAAAAI] I USER root root 127.0.0.1 :root
-Tue Jul 16 2024 13:28:42 USEROUTPUT: C[811AAAAAI] O :irc.local NOTICE sang :*** Could not resolve your hostname: Request timed out; using your IP address (127.0.0.1) instead.
-*/
 
 std::vector<std::string> Message::splitN(const std::string& str, char delimiter, size_t n) {
     std::vector<std::string> tokens;
@@ -62,10 +29,32 @@ std::vector<std::string> Message::splitN(const std::string& str, char delimiter,
     return tokens;
 }
 
+Message::e_cmd Message::findCommand(const std::string cmd_str){
+	for(int i = 1; i <= Message::CMD_SIZE; i++){
+		if (cmd_str == _commandList[i]) return static_cast<e_cmd>(i);
+	}
+	return static_cast<e_cmd>(0);
+}
+
 
 Message::Message(std::string str){
 	std::vector<std::string> ans = splitN(str, ' ', 2);
-	for(size_t i = 0; i < ans.size(); i++) 
-		std::cout << ans[i] << "\n";
-	std::cout << ans.size() << "\n";
+	_cmd_type = findCommand(ans[0]);
+	_params = ans.size() == 1 ? "" : ans[1];
+}
+
+Message::e_cmd Message::getCommand(void){return _cmd_type;}
+const std::string Message::getParams(void){return _params;}
+Message::Message(void) : _cmd_type(Message::NONE), _params("") {}
+Message::~Message(){}
+Message::Message(const Message& obj){
+	_cmd_type = obj._cmd_type;
+	_params = obj._params;
+}
+Message& Message::operator= (const Message& obj){
+	if (this != &obj){
+		_cmd_type = obj._cmd_type;
+		_params = obj._params;
+	}
+	return *this;
 }

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -1,0 +1,49 @@
+#include "../includes/Message.hpp"
+
+// Message::Message(void){
+
+// }
+// Message::~Message(){
+
+// }
+// Message::Message(const Message& obj){
+
+// }
+// Message& Message::operator= (const Message& obj){
+
+// }
+
+/*
+Tue Jul 16 2024 13:28:37 USERINPUT: C[811AAAAAI] I CAP LS 302
+Tue Jul 16 2024 13:28:37 USERINPUT: C[811AAAAAI] I JOIN :
+67 C
+65 A
+80 P
+32 ' '
+76 L
+83 S
+32 ' '
+51 3
+48 0
+50 2
+13 CR (\r)
+10 LF (\n)
+74 J
+79 O
+73 I
+78 N
+32 ' '
+58 ':'
+13 \r
+10 \n
+그다음 대기
+Tue Jul 16 2024 13:28:37 USEROUTPUT: C[811AAAAAI] O :irc.local 451 * JOIN :You have not registered.
+Tue Jul 16 2024 13:28:37 USERINPUT: C[811AAAAAI] I PASS 123
+Tue Jul 16 2024 13:28:37 USERINPUT: C[811AAAAAI] I NICK sang
+Tue Jul 16 2024 13:28:37 USERINPUT: C[811AAAAAI] I USER root root 127.0.0.1 :root
+Tue Jul 16 2024 13:28:42 USEROUTPUT: C[811AAAAAI] O :irc.local NOTICE sang :*** Could not resolve your hostname: Request timed out; using your IP address (127.0.0.1) instead.
+*/
+
+// Message::Message(std::string str){
+
+// }

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -3,9 +3,7 @@
 // Message::Message(void){
 
 // }
-// Message::~Message(){
-
-// }
+Message::~Message(){}
 // Message::Message(const Message& obj){
 
 // }
@@ -44,6 +42,30 @@ Tue Jul 16 2024 13:28:37 USERINPUT: C[811AAAAAI] I USER root root 127.0.0.1 :roo
 Tue Jul 16 2024 13:28:42 USEROUTPUT: C[811AAAAAI] O :irc.local NOTICE sang :*** Could not resolve your hostname: Request timed out; using your IP address (127.0.0.1) instead.
 */
 
-// Message::Message(std::string str){
+std::vector<std::string> Message::splitN(const std::string& str, char delimiter, size_t n) {
+    std::vector<std::string> tokens;
+    std::istringstream stream(str);
+    std::string token;
+    size_t count = 0;
 
-// }
+    while (std::getline(stream, token, delimiter) && count < n - 1) {
+        tokens.push_back(token);
+        count++;
+    }
+    // Add the remaining part of the string
+    if (stream) {
+        std::string remaining((std::istreambuf_iterator<char>(stream)), std::istreambuf_iterator<char>());
+        if (!token.empty())
+            remaining = token + delimiter + remaining;
+        tokens.push_back(remaining);
+    }
+    return tokens;
+}
+
+
+Message::Message(std::string str){
+	std::vector<std::string> ans = splitN(str, ' ', 2);
+	for(size_t i = 0; i < ans.size(); i++) 
+		std::cout << ans[i] << "\n";
+	std::cout << ans.size() << "\n";
+}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -168,3 +168,17 @@ void Server::removeClient(int client_socket) {
         _clients.erase(client_socket);
     }
 }
+
+Server::Server(void) : _port(0), _password(""), _server_fd(-1), _kqueue_fd(0) {
+    throw std::runtime_error("Server(): consturctor is not allowed");
+}
+Server::Server(const Server& obj) : 
+        _port(obj._port), _password(obj._password), _server_fd(obj._server_fd), 
+        _server_addr(obj._server_addr), _kqueue_fd(obj._kqueue_fd), _clients(obj._clients){
+    throw std::runtime_error("Server(): copy consturctor is not allowed");
+}
+Server& Server::operator= (const Server& obj){
+    (void) obj;
+	throw std::runtime_error("Server(): operator= is not allowed");
+	return *this;
+}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -110,6 +110,7 @@ void Server::handleClientEvent(struct kevent &event) {
         removeClient(client_socket);
         return;
     }
+    for (ssize_t i = 0; i < recv_byte; i++) std::cout << static_cast<int>(buffer[i]) << "\n";
 
     std::cout << "Received: " << buffer << "\n";
     std::string msg = "send: " + std::string(buffer);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -91,7 +91,7 @@ void Server::connectNewClient() {
     std::cout << "Client " << client_ip << ":" << client_port << " connected\n";
 
     Client *new_client = new Client(client_socket);
-    _clients.insert({client_socket, new_client});
+    _clients[client_socket] =  new_client;
 
     struct kevent change_event;
     EV_SET(&change_event, client_socket, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -121,13 +121,38 @@ void Server::handleClientEvent(struct kevent &event) {
     while (true){
         try {
             client >> line;
+            std::cout << line << "\n";
+            Message msg(line);
+            switch (msg.getCommand()) {
+                case Message::CAP:
+                    break;
+                case Message::PASS:
+                    break;
+                case Message::NICK:
+                case Message::USER:
+                case Message::QUIT:
+                case Message::JOIN:
+                    client << std::string(":irc.local 451 * JOIN :You have not registered.\r\n");
+                    break;
+                case Message::PART:
+                case Message::TOPIC:
+                case Message::MODE:
+                case Message::INVITE:
+                case Message::KICK:
+                case Message::PRIVMSG:
+                case Message::PING:
+                    break;
+                default:
+                    if (msg.getParams().empty())
+                        throw new std::runtime_error("empty parameter");
+            }
+            std::cout << msg.getCommand() << "\n";
+            std::cout << msg.getParams() << "\n";
         } catch(std::exception &e){
             std::cerr << e.what() << "\n";
             break;
         }
-        std::cout << line << "\n\n";
     }
-    client << std::string(":irc.local 451 * JOIN :You have not registered.\r\n");
     // write data to client
     client >> socket;
 }


### PR DESCRIPTION
# Summary
MSG를 파싱하는 간단한 class인 Message class를 구현했습니다.

# 변경사항
* Client.hpp, Server.hpp, Message.hpp 모두 orthodox cannoical form을 준수함.
* Server.cpp에 handleClient코드에 여러 메시지를 handling할 수 있는 분기문 추가
* Message class 추가
* command를 enum type으로 선언
* Message class안에서 line string 을 split해서 command와 parameter로 분할
* message에서 getCommand()와 getParameter()를 호출하면 값을 얻어올 수 있음

# 주의사항
* 이 Message class는 아직 완성된 것이 아니기 때문에 parameter를 std::string으로 단순히 넣은 상태
* 구현하기에 따라서 다른 자료구조로 변경이 가능합니다.