### PR TITLE
[FEAT] PART command 구현

### DIFF
--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -76,6 +76,7 @@ public:
     bool isModeSet(_ChannelFlag);
 
     void join(Client *, const std::string &);
+    void part(Client *);
 
     Channel &operator<<(const std::string &);
 

--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -71,6 +71,7 @@ public:
 
     void addClient(Client *);
     void addOperator(Client *);
+    void removeClient(Client *);
 
     bool isClientInChannel(Client *);
     bool isModeSet(_ChannelFlag);

--- a/includes/NumericReply.hpp
+++ b/includes/NumericReply.hpp
@@ -58,5 +58,8 @@
 #define RPL_ENDOFNAMES_366(target, channel_name) NORMAL_REPLY(366, target, channel_name + " :End of /NAMES list")
 
 #define ERR_NOSUCHCHANNEL_403(target, channel_name) ERROR_REPLY(403, target, channel_name + " :No such channel")
+#define ERR_NOTONCHANNEL_442(target, channel_name) ERROR_REPLY(442, target, channel_name + " :You're not on that channel")
+
+#define RPL_CHANNELPART(client, channel_name) (":" + USER_PREFIX(client) + " PART " + channel_name + CRLF)
 
 #endif

--- a/includes/NumericReply.hpp
+++ b/includes/NumericReply.hpp
@@ -55,8 +55,8 @@
 
 #define RPL_CHANNELJOIN(client, channel_name) (":" + USER_PREFIX(client) + " JOIN " + channel_name + CRLF)
 #define RPL_NAMREPLY_353(target, channel_name, name_list) NORMAL_REPLY(353, target, "= " + channel_name + " :" + name_list)
-
 #define RPL_ENDOFNAMES_366(target, channel_name) NORMAL_REPLY(366, target, channel_name + " :End of /NAMES list")
 
+#define ERR_NOSUCHCHANNEL_403(target, channel_name) ERROR_REPLY(403, target, channel_name + " :No such channel")
 
 #endif

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -33,11 +33,11 @@ private:
     void handleClientEvent(struct kevent &);
     void removeClient(int);
     void registerClient(Client *);
+    Channel *getExistingChannel(const std::string &);
 
     bool isValidNickname(const std::string &);
     bool isDuplicateNickname(const std::string &);
     bool isValidChannel(const std::string &);
-    Channel *getExistingChannel(const std::string &);
     void createChannel(const std::string &, Client *);
 
     void nick(Client *, const std::vector<std::string>);
@@ -45,6 +45,7 @@ private:
     void quit(Client *, const std::vector<std::string>);
     void user(Client *, const std::vector<std::string>);
     void join(Client *, const std::vector<std::string>);
+    void part(Client *, const std::vector<std::string>);
 
 public:
     Server(void);

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -32,6 +32,15 @@ void Channel::addOperator(Client *client) {
     _operators_map[client->getNickname()] = client;
 }
 
+void Channel::removeClient(Client *client) {
+    _clients.erase(client);
+    _clients_map.erase(client->getNickname());
+    _operators.erase(client);
+    _operators_map.erase(client->getNickname());
+    _guests.erase(client);
+    _guests_map.erase(client->getNickname());
+}
+
 bool Channel::isClientInChannel(Client *client) {
     return _clients.find(client) != _clients.end();
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -36,6 +36,9 @@ Server::~Server() {
     for (std::map<int, Client*>::iterator it = _clients.begin(); it != _clients.end(); ++it) {
         delete it->second;
     }
+    for (std::set<Channel *>::iterator it = _channels.begin(); it != _channels.end(); ++it) {
+        delete *it;
+    }
 }
 
 void Server::initServerInfo() {
@@ -146,6 +149,8 @@ void Server::handleClientEvent(struct kevent &event) {
                     join(&client, msg.getParams());
                     break;
                 case Message::PART:
+                    part(&client, msg.getParams());
+                    break;
                 case Message::TOPIC:
                 case Message::MODE:
                 case Message::INVITE:

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -192,6 +192,15 @@ void Server::registerClient(Client *client) {
     }
 }
 
+Channel *Server::getExistingChannel(const std::string &channel) {
+    for (std::set<Channel *>::iterator it = _channels.begin(); it != _channels.end(); ++it) {
+        if ((*it)->getName() == channel) {
+            return *it;
+        }
+    }
+    return NULL;
+}
+
 Server::Server(void) : _port(0), _password(""), _server_fd(-1), _kqueue_fd(0) {
     throw std::runtime_error("Server(): consturctor is not allowed");
 }

--- a/src/commands/join.cpp
+++ b/src/commands/join.cpp
@@ -88,12 +88,3 @@ bool Server::isValidChannel(const std::string &channel) {
     }
     return (channel[0] == '#' || channel[0] == '&');
 }
-
-Channel *Server::getExistingChannel(const std::string &channel) {
-    for (std::set<Channel *>::iterator it = _channels.begin(); it != _channels.end(); ++it) {
-        if ((*it)->getName() == channel) {
-            return *it;
-        }
-    }
-    return NULL;
-}

--- a/src/commands/part.cpp
+++ b/src/commands/part.cpp
@@ -1,0 +1,29 @@
+#include "../../includes/Server.hpp"
+#include "../../includes/Channel.hpp"
+
+void Server::part(Client *client, const std::vector<std::string> params) {
+    if (!client->isRegistered) {
+        *client << ERR_NOTREGISTERED_451(client->getNickname());
+        return;
+    }
+    if (params.empty()) {
+        *client << ERR_NEEDMOREPARAMS_461(client->getNickname());
+        return;
+    }
+
+    std::vector<std::string> channels = Message::split(params[0], ',');
+
+    for (std::vector<std::string>::iterator it = channels.begin(); it != channels.end(); ++it) {
+        Channel *channel = getExistingChannel(*it);
+        if (channel) {
+            channel->part(client);
+            // TODO: channel에 client가 없으면 제거
+        } else {
+            *client << ERR_NOSUCHCHANNEL_403(client->getNickname(), *it);
+        }
+    }
+}
+
+void Channel::part(Client *client) {
+
+}


### PR DESCRIPTION
## Summary
client가 channel에서 나가는 PART command 구현

## Description
- channel을 parameter로 받음 (여러개의 channel이 올 때, 쉼표(',')로 연결되어 들어옴)
- 해당 channel 이 있으면 해당 채널에 client 삭제(`Channel::part`)
- 채널의 모든 client에게 메세지 전송
- 채널에 client가 없으면 채널 삭제