### PR TITLE
[FEAT] Bot command 구현 및 큰 버그 해결

### DIFF
--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -6,6 +6,7 @@
 #include <set>
 #include <map>
 #include <sstream>
+#include <vector>
 
 #define CHANNEL_LENGTH 200
 

--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -84,7 +84,7 @@ public:
     bool isModeSet(_ChannelFlag);
 
     void join(Client *, const std::string &);
-    void part(Client *);
+    void part(Client *, const std::string &);
     void topic(Client *, const std::string &);
     void kick(Client *, const std::vector<std::string> &, const std::string &);
     void privmsg(Client *, const std::string &);

--- a/includes/Message.hpp
+++ b/includes/Message.hpp
@@ -23,6 +23,7 @@ public:
         KICK,
         PRIVMSG,
         PING,
+        BOT,
         CMD_SIZE
     } e_cmd;
 

--- a/includes/NumericReply.hpp
+++ b/includes/NumericReply.hpp
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <sstream>
 #include <iomanip>
-
+#include <string>
 // <message>  ::= [':' <prefix> <SPACE> ] <command> <params> <crlf>
 // <prefix>   ::= <servername> | <nick> [ '!' <user> ] [ '@' <host> ]
 // <command>  ::= <letter> { <letter> } | <number> <number> <number>
@@ -17,10 +17,22 @@
 #define CRLF "\r\n"
 #define USER_PREFIX(client) ((client).getNickname() + "!" + (client).getUsername() + "@" + (client).getHostname())
 
+inline std::string to_string(int number) {
+    std::ostringstream ss;
+    ss << number;
+    return ss.str();
+}
+
+inline std::string normal_reply_helper(int number, const std::string& target, const std::string& message) {
+    std::ostringstream ss;
+    ss << std::setw(3) << std::setfill('0') << number;
+    return ss.str() + " " + target + " " + message + CRLF;
+}
+
 #define ERROR_REPLY(number, target, message) \
-    (std::to_string(number) + " " + target + " " + message + CRLF)
+    (to_string(number) + " " + target + " " + message + CRLF)
 #define NORMAL_REPLY(number, target, message) \
-    ((std::stringstream() << std::setw(3) << std::setfill('0') << number).str() + " " + target + " " + message + CRLF)
+     (normal_reply_helper(number, target, message))
 
 // NOTE - PING_REPLIES
 #define RPL_PONG(params) ("PONG :" + params + CRLF)

--- a/includes/NumericReply.hpp
+++ b/includes/NumericReply.hpp
@@ -82,7 +82,7 @@ inline std::string normal_reply_helper(int number, const std::string& target, co
 #define ERR_USERNOTINCHANNEL_441(target, user, channel_name) ERROR_REPLY(441, target, user + " " + channel_name + " :They aren't on that channel")
 #define ERR_NOTONCHANNEL_442(target, channel_name) ERROR_REPLY(442, target, channel_name + " :You're not on that channel")
 
-#define RPL_CHANNELPART(client, channel_name) (":" + USER_PREFIX(client) + " PART " + channel_name + CRLF)
+#define RPL_CHANNELPART(client, channel_name, message) (":" + USER_PREFIX(client) + " PART " + channel_name + " " + message + CRLF)
 
 // NOTE - TOPIC
 #define RPL_NOTOPIC_331(target, channel_name) NORMAL_REPLY(331, target, channel_name + " :No topic is set")

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -10,6 +10,7 @@
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <map>
+#include <random>
 
 #include "Client.hpp"
 #include "Message.hpp"
@@ -54,6 +55,7 @@ private:
     void kick(Client *, const std::vector<std::string>);
     void privmsg(Client *, const std::vector<std::string>);
     void ping(Client *, const std::vector<std::string>);
+    void bot(Client *, const std::vector<std::string>);
 
 public:
     Server(void);

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -5,7 +5,7 @@ const std::string Message::_commandList[Message::CMD_SIZE + 1] = {
     "NICK", "USER", "QUIT", 
     "JOIN", "PART", "TOPIC", 
     "MODE", "INVITE", "KICK", 
-    "PRIVMSG", "PING"
+    "PRIVMSG", "PING", "BOT"
 };
 
 Message::Message() : _cmd_type(Message::NONE), _cmd(), _params() {}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -74,6 +74,7 @@ void Server::run() {
         // 발생한 event가 반환될 배열
         struct kevent events[10];
         int new_events = kevent(_kqueue_fd, NULL, 0, events, 10, NULL);
+        std::cout << new_events << "\n";
         if (new_events < 0) {
             throw std::runtime_error("Kevent failed");
         }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -169,6 +169,9 @@ void Server::handleClientEvent(struct kevent &event) {
                 case Message::PING:
                     ping(&client, msg.getParams());
                     break;
+                case Message::BOT:
+                    bot(&client, msg.getParams());
+                    break;
                 default:
                     client << ERR_UNKNOWNCOMMAND_421(client.getNickname(), msg.getCmd());
                     break;

--- a/src/commands/bot.cpp
+++ b/src/commands/bot.cpp
@@ -1,0 +1,13 @@
+#include "../../includes/Server.hpp"
+
+void Server::bot(Client *client, const std::vector<std::string> params){
+    (void) params;
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<int> dis(0, 9);
+    std::string nickname_list[10] = {
+        "Charlie", "Danny", "Emerson", "Lara", "Emma", 
+        "Raven", "Margot", "Wanda", "Elizabeth", "Vivian"
+    };
+    *client << NORMAL_REPLY(256, client->getNickname(), "The bot generate nickname: \"" + nickname_list[dis(gen)] + "\"");
+}

--- a/src/commands/part.cpp
+++ b/src/commands/part.cpp
@@ -11,25 +11,29 @@ void Server::part(Client *client, const std::vector<std::string> params) {
         return;
     }
 
+    std::string part_message = std::string();
+    for (std::vector<std::string>::const_iterator it = params.begin() + 1; it != params.end(); ++it) {
+        part_message += *it + " ";
+    }
     std::vector<std::string> channels = Message::split(params[0], ',');
     for (std::vector<std::string>::iterator it = channels.begin(); it != channels.end(); ++it) {
         Channel *channel = getExistingChannel(*it);
         if (channel) {
-            channel->part(client);
+            channel->part(client, part_message);
         } else {
             *client << ERR_NOSUCHCHANNEL_403(client->getNickname(), *it);
         }
     }
 }
 
-void Channel::part(Client *client) {
+void Channel::part(Client *client, const std::string &part_message) {
     if (!isClientInChannel(client)) {
         *client << ERR_NOTONCHANNEL_442(client->getNickname(), _name);
         return;
     }
 
-    *this << RPL_CHANNELPART(*client, _name);
-    *client << RPL_CHANNELPART(*client, _name);
+    *this << RPL_CHANNELPART(*client, _name, part_message);
+    *client << RPL_CHANNELPART(*client, _name, part_message);
     Channel::removeClient(client);
 
     // client가 없으면 channel 삭제

--- a/src/commands/privmsg.cpp
+++ b/src/commands/privmsg.cpp
@@ -29,7 +29,6 @@ void Server::privmsg(Client *client, const std::vector<std::string> params) {
             Client *target = getClientbyNickname(*it);
             if (target) {
                 *target << RPL_PRIVMSG(*client, target->getNickname(), message);
-                std::cout << RPL_PRIVMSG(*client, target->getNickname(), message) << "\n";
                 *target >> target->getSocket();
             } else {
                 *client << ERR_NOSUCHNICK_401(client->getNickname(), *it);

--- a/src/commands/privmsg.cpp
+++ b/src/commands/privmsg.cpp
@@ -29,6 +29,8 @@ void Server::privmsg(Client *client, const std::vector<std::string> params) {
             Client *target = getClientbyNickname(*it);
             if (target) {
                 *target << RPL_PRIVMSG(*client, target->getNickname(), message);
+                std::cout << RPL_PRIVMSG(*client, target->getNickname(), message) << "\n";
+                *target >> target->getSocket();
             } else {
                 *client << ERR_NOSUCHNICK_401(client->getNickname(), *it);
             }

--- a/src/commands/topic.cpp
+++ b/src/commands/topic.cpp
@@ -31,8 +31,7 @@ void Channel::topic(Client *client, const std::string &topic) {
             *client << RPL_TOPIC_332(client->getNickname(), _name, _topic);
         }
     } else {
-        // TODO: operator만 topic 설정할 수 있는지 확인
-        if (isModeSet(SET_TOPIC) && !isOperator(client)) {
+        if ((isModeSet(SET_TOPIC) && !isOperator(client)) || !isModeSet(SET_TOPIC)) {
             *client << ERR_CHANOPRIVSNEEDED_482(client->getNickname(), _name);
         } else {
             setTopic(client, topic);


### PR DESCRIPTION
# Summary
* bonus에 해당하는 bot command를 구현했습니다.
* privmsg관련 버그를 해결했습니다.
* imac에서 numeric reply 매크로가 작동 안하는 버그를 해결했습니다.
* bonus에 해당하는 파일 전송 관련 커맨드를 테스트 했습니다.

# Description
* irc bonuse에 해당하는 bot를 만들었습니다. 이 bot은 nc command에서 bot을 입력하면 작동하며, 랜덤 nickname을 보여줍니다.
* irc bonus에 해당하는 파일 전송 커맨드를 작동했습니다. 작동 방법은 다음과 같습니다.
     * 파일 전송 `/dcc send ${상대 nickname} ${파일 경로} `
     * 파일 받기 `/dcc get `
     * 특정 imac에서 작동이 안되고, docker에서 작동을 하는것으로 보아서 이건 디팬스 여부가 필요해보입니다.
* privmsg는 2가지 경우가 있습니다.
    * 채널 전체에게 보내기 -> irssi에서 `/2`로 이동 가능, irssi에서 그냥 메시지 입력하면 자동으로 이 기능 수행
    * 개인메시지 보내기 -> irssi에서 `/3`으로 이동 가능, irssi에서 `/msg ${상대 nickname} ${msg}`
    * 여기에서 개인 메시지 보내기 기능이 작동이 잘 안되는 부분을 해결했습니다. -> ping 이 보내야지 밀린 msg가 넘어감
* m1 mac은 작동하는데 인텔 맥에서는 작동이 안되어서 생기는 컴파일 에러를 해결했습니다. 
    * numeric reply.hpp에 inline 함수로 해결 
### 7월 26일 추가
* mode -t를 해서 topic 설정 권한을 제거해도 topic을 설정하는 버그를 수정했습니다. @jiyuneel  -> if문에 topic없을때 경우도 추가함
* part 메시지를 할때 option으로 part message를 추가했습니다
## to_string 함수는 c++11 함수여서 허용 함수가 아닙니다. -> 그것도 변경함 @jiyuneel 